### PR TITLE
Rename initialize to initializePackage

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -25,7 +25,7 @@ class MainModel {
         requirePackages('tree-view').then(([treeView]) => {
             this.treeView = treeView;
             if (treeView.treeView && treeView.treeView.isVisible()) {
-                this.initialize();
+                this.initializePackage();
             } else {
                 // tree-view not exist give a tips
                 let subscriptions = new CompositeDisposable();
@@ -33,7 +33,7 @@ class MainModel {
                     if (treeView.treeView && treeView.treeView.isVisible() && atom.project.rootDirectories.length) {
                         subscriptions.dispose();
                         listener.disposalAction();
-                        this.initialize();
+                        this.initializePackage();
                     }
                 };
                 let listener = atom.project.onDidChangePaths((rootDirectories) => {
@@ -72,7 +72,7 @@ class MainModel {
         this.treeView = null;
     }
 
-    initialize () {
+    initializePackage () {
         // add commands
         // if tree-view is changed, show or hide the search-bar-view but do not change the 'active' status
         this.view = new View(this.treeView);


### PR DESCRIPTION
As of Atom 1.14, any method named `initialize` on the main module of a package will be automatically invoked by Atom before calling `activate`. You can read more about the change in this [pull request to Atom's documentation](https://github.com/atom/flight-manual.atom.io/pull/300/files).

Since your package's `initialize` method wasn't written with this behavior in mind, we've renamed it for you to avoid unexpected breakage.

Atom 1.14 should reach the beta channel in early January 2017 and will be on stable in early February 2017. Please merge and test out this PR before then to prevent issues, and let us know if you have any questions.

Thanks for your contributions to the Atom community! 🙇 

/cc @lixinliang 