### PR TITLE
fix: directory doesn't always have lowerCasePath.

### DIFF
--- a/lib/module/filter.js
+++ b/lib/module/filter.js
@@ -68,7 +68,7 @@ export default function filter ({ tags, $treeView }) {
     );
 
     for (let project of projects) {
-        const relative = path.relative.bind(path, path.join(project.directory.lowerCasePath, '..'));
+        const relative = path.relative.bind(path, path.join(project.directory.path.toLowerCase(), '..'));
         const items = Array.from(
             project.querySelectorAll(
                 '.project-root > .list-tree .list-item'


### PR DESCRIPTION
I think directory doesn't always have lowerCasePath.

https://github.com/atom/tree-view/blob/da385f7575503cb9c23ee936997b4e4ba05de357/lib/directory.coffee#L22

```
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.relative (path.js:1226:5)
    at /home/dycooon/.atom/packages/tree-view-search-bar/lib/module/filter.js:80:30
    at Array.forEach (native)
    at _loop (/home/dycooon/.atom/packages/tree-view-search-bar/lib/module/filter.js:78:19)
    at filter (/home/dycooon/.atom/packages/tree-view-search-bar/lib/module/filter.js:70:35)
    at Vue$3.filter (/home/dycooon/.atom/packages/tree-view-search-bar/lib/views/app.vue:152:58)
    at Vue$3.boundFn [as filter] (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue/dist/vue.js:193:12)
    at Vue$3.change (/home/dycooon/.atom/packages/tree-view-search-bar/lib/views/app.vue:209:18)
    at VueComponent.boundFn (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue/dist/vue.js:192:14)
    at VueComponent.tagChange (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue-input-tag/src/InputTag.vue:87:14)
    at VueComponent.boundFn [as tagChange] (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue/dist/vue.js:193:12)
    at VueComponent.addNew (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue-input-tag/src/InputTag.vue:55:14)
    at Proxy.boundFn (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue/dist/vue.js:192:14)
    at _c.on.keydown (evalmachine.<anonymous>:2:916)
    at invoker (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue/dist/vue.js:1945:19)
    at HTMLInputElement.fn._withTask.fn._withTask (/home/dycooon/.atom/packages/tree-view-search-bar/node_modules/vue/dist/vue.js:1784:18)

```

Atom    : 1.21.2
Electron: 1.6.15
Chrome  : 56.0.2924.87
Node    : 7.4.0
OS  :  ubuntu 16.04 LTS